### PR TITLE
Remove LOWER functions on file properties/metadata

### DIFF
--- a/emc-metalnx-core/src/main/java/com/emc/metalnx/core/domain/entity/DataGridMetadataSearch.java
+++ b/emc-metalnx-core/src/main/java/com/emc/metalnx/core/domain/entity/DataGridMetadataSearch.java
@@ -43,10 +43,10 @@ public class DataGridMetadataSearch {
 		String val = addSQLCharToQueryParamBasedOnOperator(this.value);
 		String theUnit = addSQLCharToQueryParamBasedOnOperator(unit);
 
-		String attrQuery = hasAttr ? String.format(" LOWER( %s ) = LOWER( '%s' ) ", attrColName, this.attribute) : "";
-		String valueQuery = hasVal ? String.format(" LOWER( %s ) %s LOWER( %s ) ", valueColName, this.operator, val)
+		String attrQuery = hasAttr ? String.format(" %s = '%s' ", attrColName, this.attribute) : "";
+		String valueQuery = hasVal ? String.format(" %s %s %s ", valueColName, this.operator, val)
 				: "";
-		String unitQuery = hasUnit ? String.format(" LOWER( %s ) %s LOWER( %s ) ", unitColName, this.operator, theUnit)
+		String unitQuery = hasUnit ? String.format(" %s %s %s ", unitColName, this.operator, theUnit)
 				: "";
 
 		if (hasAttr && (hasVal || hasUnit)) {

--- a/emc-metalnx-core/src/test/java/com/emc/metalnx/core/domain/entity/DataGridMetadataSearchTest.java
+++ b/emc-metalnx-core/src/test/java/com/emc/metalnx/core/domain/entity/DataGridMetadataSearchTest.java
@@ -17,7 +17,7 @@ public class DataGridMetadataSearchTest {
 		String queryString = dataGridMetadataSearch.getSpecQueryAsString();
 		Assert.assertNotNull(queryString);
 		Assert.assertEquals(
-				" SELECT map.object_id AS map_object_id  FROM R_OBJT_METAMAP map  JOIN (      SELECT m.meta_id, m.meta_attr_name, m.meta_attr_value     FROM R_META_MAIN m  WHERE   LOWER( m.meta_attr_name ) = LOWER( 'Sîne klâwen durh die wolken sint geslagen' )  AND   LOWER( m.meta_attr_value ) = LOWER(  'На берегу пустынных волн'  )  AND  LOWER( m.meta_attr_unit ) = LOWER(  'Ég get etið gler án þess að meiða mig'  )   )  AS metadata ON (metadata.meta_id = map.meta_id)  GROUP BY map.object_id  HAVING COUNT(map.meta_id) > 0 ",
+				" SELECT map.object_id AS map_object_id  FROM R_OBJT_METAMAP map  JOIN (      SELECT m.meta_id, m.meta_attr_name, m.meta_attr_value     FROM R_META_MAIN m  WHERE   ( m.meta_attr_name ) = ( 'Sîne klâwen durh die wolken sint geslagen' )  AND   ( m.meta_attr_value ) = (  'На берегу пустынных волн'  )  AND  ( m.meta_attr_unit ) = (  'Ég get etið gler án þess að meiða mig'  )   )  AS metadata ON (metadata.meta_id = map.meta_id)  GROUP BY map.object_id  HAVING COUNT(map.meta_id) > 0 ",
 				queryString);
 
 	}

--- a/emc-metalnx-services/src/main/java/com/emc/metalnx/services/irods/utils/MysqlSpecificQueryProviderImpl.java
+++ b/emc-metalnx-services/src/main/java/com/emc/metalnx/services/irods/utils/MysqlSpecificQueryProviderImpl.java
@@ -166,7 +166,7 @@ public class MysqlSpecificQueryProviderImpl implements SpecificQueryProvider {
 				|| inAttribute == FilePropertyField.MODIFICATION_DATE;
 
 		if (inOperator == DataGridSearchOperatorEnum.LIKE || inOperator == DataGridSearchOperatorEnum.NOT_LIKE) {
-			whereClause = String.format(" LOWER( fileProperties.%s ) %s LOWER( '%%%s%%' )", attribute, operator, value);
+			whereClause = String.format(" fileProperties.%s %s '%%%s%%'", attribute, operator, value);
 		} else if (isAttributeEqualsDate && inOperator == DataGridSearchOperatorEnum.EQUAL) {
 			whereClause = String.format(" fileProperties.%s BETWEEN %s AND %d", attribute, value,
 					Long.parseLong(value) + 60);
@@ -174,7 +174,7 @@ public class MysqlSpecificQueryProviderImpl implements SpecificQueryProvider {
 				|| inAttribute == FilePropertyField.SIZE) {
 			whereClause = String.format(" fileProperties.%s %s %s", attribute, operator, value);
 		} else {
-			whereClause = String.format(" LOWER( fileProperties.%s ) %s LOWER( '%s' )", attribute, operator, value);
+			whereClause = String.format(" fileProperties.%s %s '%s'", attribute, operator, value);
 		}
 
 		return whereClause;

--- a/emc-metalnx-services/src/main/java/com/emc/metalnx/services/irods/utils/PostgresSpecificQueryProviderImpl.java
+++ b/emc-metalnx-services/src/main/java/com/emc/metalnx/services/irods/utils/PostgresSpecificQueryProviderImpl.java
@@ -167,7 +167,7 @@ public class PostgresSpecificQueryProviderImpl implements SpecificQueryProvider 
 				|| inAttribute == FilePropertyField.MODIFICATION_DATE;
 
 		if (inOperator == DataGridSearchOperatorEnum.LIKE || inOperator == DataGridSearchOperatorEnum.NOT_LIKE) {
-			whereClause = String.format(" LOWER( fileProperties.%s ) %s LOWER( '%%%s%%' )", attribute, operator, value);
+			whereClause = String.format(" fileProperties.%s %s '%%%s%%'", attribute, operator, value);
 		} else if (isAttributeEqualsDate && inOperator == DataGridSearchOperatorEnum.EQUAL) {
 			whereClause = String.format(" fileProperties.%s BETWEEN %s AND %d", attribute, value,
 					Long.parseLong(value) + 60);
@@ -175,7 +175,7 @@ public class PostgresSpecificQueryProviderImpl implements SpecificQueryProvider 
 				|| inAttribute == FilePropertyField.SIZE) {
 			whereClause = String.format(" fileProperties.%s %s %s", attribute, operator, value);
 		} else {
-			whereClause = String.format(" LOWER( fileProperties.%s ) %s LOWER( '%s' )", attribute, operator, value);
+			whereClause = String.format(" fileProperties.%s %s '%s'", attribute, operator, value);
 		}
 
 		return whereClause;


### PR DESCRIPTION
Database queries for metadata or file properties cannot use indices if
the function LOWER is called on the select query. We therefore remove
the LOWER functions altogether. This is a breaking change, making
metadata queries case sensitive, but this copies the behaviour of iquest
calls or wildcard behaviour of imeta.

As a result, mysql setups handle metadata searches better on large databases.

Signed-off-by: Peter Verraedt <peter.verraedt@kuleuven.be>