### PR TITLE
Cleanup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jargon Extensions iRODS-EXT
 
-Extended support in Jargon for advanced iRODS mid-tier capabilities using the IRODS-EXT database. This package is an implementation of the original jargon-extensions reference implementation. The prior version was associated with the cloud browser, this follow-on implements the same extension interfaces to track MetaLnx, and will attempt to provide a common API that bridges several projects, giving out-of-the-box baseline functionality.
+Extended support in Jargon for advanced iRODS mid-tier capabilities. This package is an implementation of the original jargon-extensions reference implementation. The prior version was associated with the cloud browser, this follow-on implements the same extension interfaces to track MetaLnx, and will attempt to provide a common API that bridges several projects, giving out-of-the-box baseline functionality.
 
 ## Changes
 

--- a/emc-metalnx-core/attic/TestCreateTicketWithGroupRestriction.java
+++ b/emc-metalnx-core/attic/TestCreateTicketWithGroupRestriction.java
@@ -39,7 +39,7 @@ public class TestCreateTicketWithGroupRestriction {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-core/attic/TestDownloadWithTicket.java
+++ b/emc-metalnx-core/attic/TestDownloadWithTicket.java
@@ -48,7 +48,7 @@ public class TestDownloadWithTicket {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-core/attic/TestTicketAuthenticatedAccess.java
+++ b/emc-metalnx-core/attic/TestTicketAuthenticatedAccess.java
@@ -56,10 +56,10 @@ public class TestTicketAuthenticatedAccess {
 	@Value("${irods.port}")
 	private String port;
 
-	@Value("${jobs.irods.username}")
+	@Value("${irods.admin.user}")
 	private String username;
 
-	@Value("${jobs.irods.password}")
+	@Value("${irods.admin.password}")
 	private String password;
 
 	@Autowired

--- a/emc-metalnx-core/attic/TestTicketWithGroupRestriction.java
+++ b/emc-metalnx-core/attic/TestTicketWithGroupRestriction.java
@@ -40,7 +40,7 @@ public class TestTicketWithGroupRestriction {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-core/attic/TestUploadWithTicket.java
+++ b/emc-metalnx-core/attic/TestUploadWithTicket.java
@@ -42,7 +42,7 @@ public class TestUploadWithTicket {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-core/pom.xml
+++ b/emc-metalnx-core/pom.xml
@@ -247,12 +247,6 @@
 
 									######################################
 
-									jobs.irods.username=${jargon.test.irods.admin}
-									jobs.irods.password=${jargon.test.irods.admin.password}
-									jobs.irods.auth.scheme=${metalnx.auth.scheme}
-									runSyncJobs=true
-
-
 									rmd.connection.timeout=500
 									rmd.connection.port=8000
 

--- a/emc-metalnx-services/pom.xml
+++ b/emc-metalnx-services/pom.xml
@@ -244,12 +244,6 @@
 
 									######################################
 
-									jobs.irods.username=${jargon.test.irods.admin}
-									jobs.irods.password=${jargon.test.irods.admin.password}
-									jobs.irods.auth.scheme=${metalnx.auth.scheme}
-									runSyncJobs=true
-
-
 									rmd.connection.timeout=500
 									rmd.connection.port=8000
 

--- a/emc-metalnx-services/src/main/java/com/emc/metalnx/context/EncodedPropertiesConfigurer.java
+++ b/emc-metalnx-services/src/main/java/com/emc/metalnx/context/EncodedPropertiesConfigurer.java
@@ -22,7 +22,7 @@ import java.util.*;
 public class EncodedPropertiesConfigurer extends PropertyPlaceholderConfigurer {
 
     private static final String PROPERTIES_TO_BE_DECODED = "encoded.properties";
-    private static final String DEFAULT_ENCODED_FIELDS = "db.password,jobs.irods.password";
+    private static final String DEFAULT_ENCODED_FIELDS = "db.password,irods.admin.password";
     private static final String PWD_SALT = "!M3t4Lnx@1234";
 
     private static final Logger logger = LoggerFactory.getLogger(EncodedPropertiesConfigurer.class);

--- a/emc-metalnx-services/src/main/java/com/emc/metalnx/services/configuration/ConfigServiceImpl.java
+++ b/emc-metalnx-services/src/main/java/com/emc/metalnx/services/configuration/ConfigServiceImpl.java
@@ -51,13 +51,13 @@ public class ConfigServiceImpl implements ConfigService {
 	@Value("${irods.zoneName}")
 	private String irodsZone;
 
-	@Value("${jobs.irods.username}")
-	private String irodsJobUser;
+	@Value("${irods.admin.user}")
+	private String irodsAdminUser;
 
-	@Value("${jobs.irods.password}")
-	private String irodsJobPassword;
+	@Value("${irods.admin.password}")
+	private String irodsAdminPassword;
 
-	@Value("${jobs.irods.auth.scheme}")
+	@Value("${irods.auth.scheme}")
 	private String irodsAuthScheme;
 
 	@Value("${populate.msi.enabled}")
@@ -189,13 +189,13 @@ public class ConfigServiceImpl implements ConfigService {
 	}
 
 	@Override
-	public String getIrodsJobUser() {
-		return irodsJobUser;
+	public String getIrodsAdminUser() {
+		return irodsAdminUser;
 	}
 
 	@Override
-	public String getIrodsJobPassword() {
-		return irodsJobPassword;
+	public String getIrodsAdminPassword() {
+		return irodsAdminPassword;
 	}
 
 	@Override
@@ -367,8 +367,8 @@ public class ConfigServiceImpl implements ConfigService {
 		if (irodsZone != null) {
 			builder.append("irodsZone=").append(irodsZone).append(", ");
 		}
-		if (irodsJobUser != null) {
-			builder.append("irodsJobUser=").append(irodsJobUser).append(", ");
+		if (irodsAdminUser != null) {
+			builder.append("irodsAdminUser=").append(irodsAdminUser).append(", ");
 		}
 		if (irodsAuthScheme != null) {
 			builder.append("irodsAuthScheme=").append(irodsAuthScheme).append(", ");
@@ -439,13 +439,13 @@ public class ConfigServiceImpl implements ConfigService {
 	}
 
 	@Override
-	public void setIrodsJobUser(String irodsJobUser) {
-		this.irodsJobUser = irodsJobUser;
+	public void setIrodsAdminUser(String irodsAdminUser) {
+		this.irodsAdminUser = irodsAdminUser;
 	}
 
 	@Override
-	public void setIrodsJobPassword(String irodsJobPassword) {
-		this.irodsJobPassword = irodsJobPassword;
+	public void setIrodsAdminPassword(String irodsAdminPassword) {
+		this.irodsAdminPassword = irodsAdminPassword;
 	}
 
 	@Override

--- a/emc-metalnx-services/src/main/java/com/emc/metalnx/services/irods/AdminServicesImpl.java
+++ b/emc-metalnx-services/src/main/java/com/emc/metalnx/services/irods/AdminServicesImpl.java
@@ -102,8 +102,8 @@ public class AdminServicesImpl implements AdminServices {
 		String host = configService.getIrodsHost();
 		int port = Integer.parseInt(configService.getIrodsPort());
 		String zone = configService.getIrodsZone();
-		String user = configService.getIrodsJobUser();
-		String password = configService.getIrodsJobPassword();
+		String user = configService.getIrodsAdminUser();
+		String password = configService.getIrodsAdminPassword();
 		String authScheme = configService.getIrodsAuthScheme();
 		String resc = "";
 		String homeDir = "";

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestAddDataGridMetadataListToColls.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestAddDataGridMetadataListToColls.java
@@ -39,7 +39,7 @@ public class TestAddDataGridMetadataListToColls {
 	@Value("${irods.zoneName}")
 	private String zone;
 
-	@Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
 	private String username;
 
 	@Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestAddDataGridMetadataListToObjs.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestAddDataGridMetadataListToObjs.java
@@ -39,7 +39,7 @@ public class TestAddDataGridMetadataListToObjs {
 	@Value("${irods.zoneName}")
 	private String zone;
 
-	@Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
 	private String username;
 
 	@Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestAddDataGridMetadataToColls.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestAddDataGridMetadataToColls.java
@@ -37,7 +37,7 @@ public class TestAddDataGridMetadataToColls {
 	@Value("${irods.zoneName}")
 	private String zone;
 
-	@Value("${jobs.irods.username}")
+	@Value("${irods.admin.user}")
 	private String username;
 
 	@Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestAddDataGridMetadataToObjs.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestAddDataGridMetadataToObjs.java
@@ -39,7 +39,7 @@ public class TestAddDataGridMetadataToObjs {
 	@Value("${irods.zoneName}")
 	private String zone;
 
-	@Value("${jobs.irods.username}")
+	@Value("${irods.admin.user}")
 	private String username;
 
 	@Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestAddMetadataToColls.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestAddMetadataToColls.java
@@ -39,7 +39,7 @@ public class TestAddMetadataToColls {
 	@Value("${irods.zoneName}")
 	private String zone;
 
-	@Value("${jobs.irods.username}")
+	@Value("${irods.admin.user}")
 	private String username;
 
 	@Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestAddMetadataToObjs.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestAddMetadataToObjs.java
@@ -42,7 +42,7 @@ public class TestAddMetadataToObjs {
 	@Value("${irods.zoneName}")
 	private String zone;
 
-	@Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
 	private String username;
 
 	@Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestCopyCollWithMetadata.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestCopyCollWithMetadata.java
@@ -39,7 +39,7 @@ public class TestCopyCollWithMetadata {
 	@Value("${irods.zoneName}")
 	private String zone;
 
-	@Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
 	private String username;
 
 	@Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestCopyObjWithMetadata.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestCopyObjWithMetadata.java
@@ -42,7 +42,7 @@ public class TestCopyObjWithMetadata {
 	@Value("${irods.zoneName}")
 	private String zone;
 
-	@Value("${jobs.irods.username}")
+	@Value("${irods.admin.user}")
 	private String username;
 
 	@Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestMetadataCase.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/metadata/TestMetadataCase.java
@@ -61,7 +61,7 @@ public class TestMetadataCase {
 	@Value("${irods.zoneName}")
 	private String zone;
 
-	@Value("${jobs.irods.username}")
+	@Value("${irods.admin.user}")
 	private String username;
 
 	@Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/permissions/TestMostRestrictivePermission.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/permissions/TestMostRestrictivePermission.java
@@ -39,7 +39,7 @@ public class TestMostRestrictivePermission {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/permissions/TestReadPermissionOnFiles.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/permissions/TestReadPermissionOnFiles.java
@@ -40,7 +40,7 @@ public class TestReadPermissionOnFiles {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/ticketclient/TestTicketWithByteLimit.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/ticketclient/TestTicketWithByteLimit.java
@@ -40,7 +40,7 @@ public class TestTicketWithByteLimit {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/ticketclient/TestTicketWithExpirationDate.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/ticketclient/TestTicketWithExpirationDate.java
@@ -42,7 +42,7 @@ public class TestTicketWithExpirationDate {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/ticketclient/TestTicketWithFilesLimit.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/ticketclient/TestTicketWithFilesLimit.java
@@ -40,7 +40,7 @@ public class TestTicketWithFilesLimit {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/ticketclient/TestTicketWithHostRestriction.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/ticketclient/TestTicketWithHostRestriction.java
@@ -38,7 +38,7 @@ public class TestTicketWithHostRestriction {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Value("${irods.host}")

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/ticketclient/TestTicketWithUserRestriction.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/ticketclient/TestTicketWithUserRestriction.java
@@ -38,7 +38,7 @@ public class TestTicketWithUserRestriction {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/ticketclient/TestTicketWithUsesLimit.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/ticketclient/TestTicketWithUsesLimit.java
@@ -41,7 +41,7 @@ public class TestTicketWithUsesLimit {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateDuplicatedTicket.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateDuplicatedTicket.java
@@ -33,7 +33,7 @@ public class TestCreateDuplicatedTicket {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicket.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicket.java
@@ -34,7 +34,7 @@ public class TestCreateTicket {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicketWithByteLimit.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicketWithByteLimit.java
@@ -39,7 +39,7 @@ public class TestCreateTicketWithByteLimit {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicketWithExpirationDate.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicketWithExpirationDate.java
@@ -41,7 +41,7 @@ public class TestCreateTicketWithExpirationDate {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicketWithFilesLimit.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicketWithFilesLimit.java
@@ -39,7 +39,7 @@ public class TestCreateTicketWithFilesLimit {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicketWithHostRestriction.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicketWithHostRestriction.java
@@ -36,7 +36,7 @@ public class TestCreateTicketWithHostRestriction {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Value("${irods.host}")

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicketWithUserRestriction.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicketWithUserRestriction.java
@@ -37,7 +37,7 @@ public class TestCreateTicketWithUserRestriction {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicketWithUsesLimit.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestCreateTicketWithUsesLimit.java
@@ -39,7 +39,7 @@ public class TestCreateTicketWithUsesLimit {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestDeleteTickets.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestDeleteTickets.java
@@ -39,7 +39,7 @@ public class TestDeleteTickets {
 	@Value("${irods.zoneName}")
 	private String zone;
 
-	@Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
 	private String username;
 
 	@Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestFindTicket.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestFindTicket.java
@@ -48,7 +48,7 @@ public class TestFindTicket {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Value("${irods.host}")

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestModifyTicket.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestModifyTicket.java
@@ -45,7 +45,7 @@ public class TestModifyTicket {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Value("${irods.host}")

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestTicketService.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/tickets/TestTicketService.java
@@ -36,7 +36,7 @@ public class TestTicketService {
     @Value("${irods.zoneName}")
     private String zone;
 
-    @Value("${jobs.irods.username}")
+    @Value("${irods.admin.user}")
     private String username;
 
     @Autowired

--- a/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/upload/TestUploadService.java
+++ b/emc-metalnx-services/src/test/java/com/emc/metalnx/services/tests/upload/TestUploadService.java
@@ -42,7 +42,7 @@ public class TestUploadService {
 	@Value("${irods.zoneName}")
 	private String zone;
 
-	@Value("${jobs.irods.username}")
+	@Value("${irods.admin.user}")
 	private String user;
 
 	@Autowired

--- a/emc-metalnx-services/src/test/resources/test-services-context.xml
+++ b/emc-metalnx-services/src/test/resources/test-services-context.xml
@@ -40,8 +40,8 @@
 	<bean id="irodsAccount" class="org.irods.jargon.core.connection.IRODSAccount">
 		<constructor-arg value="${irods.host}"></constructor-arg>
 		<constructor-arg value="${irods.port}"></constructor-arg>
-		<constructor-arg value="${jobs.irods.username}"></constructor-arg>
-		<constructor-arg value="${jobs.irods.password}"></constructor-arg>
+		<constructor-arg value="${irods.admin.user}"></constructor-arg>
+		<constructor-arg value="${irods.admin.password}"></constructor-arg>
 		<constructor-arg value=""></constructor-arg>
 		<constructor-arg value="${irods.zoneName}"></constructor-arg>
 		<constructor-arg value="demoResc"></constructor-arg>

--- a/irodsext-data-profiler/pom.xml
+++ b/irodsext-data-profiler/pom.xml
@@ -144,12 +144,6 @@
 
 									######################################
 
-									jobs.irods.username=${jargon.test.irods.admin}
-									jobs.irods.password=${jargon.test.irods.admin.password}
-									jobs.irods.auth.scheme=${metalnx.auth.scheme}
-									runSyncJobs=true
-
-
 									rmd.connection.timeout=500
 									rmd.connection.port=8000
 

--- a/irodsext-data-profiler/src/main/java/com/emc/metalnx/services/interfaces/ConfigService.java
+++ b/irodsext-data-profiler/src/main/java/com/emc/metalnx/services/interfaces/ConfigService.java
@@ -79,20 +79,20 @@ public interface ConfigService {
 	String getIrodsZone();
 
 	/**
-	 * Find the jobs username.
+	 * Find the admin username.
 	 *
 	 * @return String representing the username used for synchronizing Metalnx and
 	 *         iRODS.
 	 */
-	String getIrodsJobUser();
+	String getIrodsAdminUser();
 
 	/**
-	 * Find the jobs password.
+	 * Find the admin password.
 	 *
 	 * @return String representing the password used for synchronizing Metalnx and
 	 *         iRODS.
 	 */
-	String getIrodsJobPassword();
+	String getIrodsAdminPassword();
 
 	/**
 	 * Find the authentication scheme used for authenticating against iRODS.
@@ -156,8 +156,8 @@ public interface ConfigService {
 	void setDownloadLimit(long downloadLimit);
 	void setPopulateMsiEnabled(boolean populateMsiEnabled);
 	void setIrodsAuthScheme(String irodsAuthScheme);
-	void setIrodsJobPassword(String irodsJobPassword);
-	void setIrodsJobUser(String irodsJobUser);
+	void setIrodsAdminPassword(String irodsAdminPassword);
+	void setIrodsAdminUser(String irodsAdminUser);
 	void setIrodsZone(String irodsZone);
 	void setIrodsPort(String irodsPort);
 	void setIrodsHost(String irodsHost);


### PR DESCRIPTION
1. Changed AdminServices and Config services to use the following configurations parameters since there are no longer jobs:
    - jobs.irods.username -> irods.admin.user
    - jobs.irods.password -> irods.admin.password
    - jobs.irods.auth.scheme -> irods.auth.scheme
2. Updated README.md to remove the reference to the irods-ext database.